### PR TITLE
Add `concurrency` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,16 @@
 'use strict';
 const pReflect = require('p-reflect');
+const pLimit = require('p-limit');
 
-module.exports = iterable => Promise.all(iterable.map(pReflect));
+module.exports = (iterable, opts) => {
+	opts = Object.assign({
+		concurrency: Infinity
+	}, opts);
+
+	if (!(typeof opts.concurrency === 'number' && opts.concurrency >= 1)) {
+		throw new TypeError(`Expected \`concurrency\` to be a number from 1 and up, got \`${opts.concurrency}\` (${typeof opts.concurrency})`);
+	}
+
+	const limit = pLimit(opts.concurrency);
+	return Promise.all(iterable.map(item => pReflect(limit(() => item))));
+};

--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
 'use strict';
 const pReflect = require('p-reflect');
+const pLimit = require('p-limit');
 
 module.exports = (iterable, opts) => {
-	const pLimit = require('p-limit');
-
 	opts = Object.assign({
 		concurrency: Infinity
 	}, opts);

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 'use strict';
 const pReflect = require('p-reflect');
-const pLimit = require('p-limit');
 
 module.exports = (iterable, opts) => {
+	const pLimit = require('p-limit');
+
 	opts = Object.assign({
 		concurrency: Infinity
 	}, opts);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "bluebird"
   ],
   "dependencies": {
-    "p-reflect": "^1.0.0"
+    "p-reflect": "^1.0.0",
+    "p-limit": "^1.2.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "ava": "*",
     "delay": "^1.3.1",
+    "mock-require": "^3.0.1",
     "xo": "*"
   },
   "xo": {

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ pSettle(files).then(result => {
 
 ## API
 
-### pSettle(input)
+### pSettle(input, [options])
 
 Returns a `Promise` that is fulfilled when all promises in `input` are settled.
 
@@ -55,6 +55,18 @@ The fulfilled value is an array of objects with the following properties:
 #### input
 
 Type: `Iterable<Promise|any>`
+
+#### options
+
+Type: `Object`
+
+##### concurrency
+
+Type: `number`<br>
+Default: `Infinity`<br>
+Minimum: `1`
+
+Number of concurrently pending promises.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -1,6 +1,21 @@
 import test from 'ava';
 import delay from 'delay';
+import mock from 'mock-require';
+import realPLimit from 'p-limit';
 import m from './';
+
+let limitCalls = [];
+mock('p-limit', concurrency => {
+	const limit = realPLimit(concurrency);
+	const mockLimit = itemFunction => {
+		limitCalls.push({
+			concurrency,
+			item: itemFunction()
+		});
+		return limit(itemFunction);
+	};
+	return mockLimit;
+});
 
 test('main', async t => {
 	t.deepEqual(
@@ -23,6 +38,28 @@ test('main', async t => {
 			}
 		]
 	);
+});
+
+test('concurrency and item are passed to p-limit', async t => {
+	limitCalls = [];
+
+	const arraySize = 100;
+	const concurrency = 4;
+	const array = new Array(arraySize).fill(0).map((_, i) => Promise.resolve(i));
+	const resolvedCalls = new Array(arraySize).fill(0).map(() => ({concurrency}));
+
+	await m(array, {concurrency});
+
+	await limitCalls.map(limitCall => limitCall.item).forEach((item, index) => {
+		item.then(data => {
+			resolvedCalls[index].item = data;
+		});
+	});
+
+	await t.deepEqual(resolvedCalls, new Array(arraySize).fill(0).map((_, item) => ({
+		concurrency,
+		item
+	})));
 });
 
 test('handles empty iterable', async t => {

--- a/test.js
+++ b/test.js
@@ -2,7 +2,6 @@ import test from 'ava';
 import delay from 'delay';
 import mock from 'mock-require';
 import realPLimit from 'p-limit';
-import m from '.';
 
 let limitCalls = [];
 mock('p-limit', concurrency => {
@@ -16,6 +15,8 @@ mock('p-limit', concurrency => {
 	};
 	return mockLimit;
 });
+
+const m = mock.reRequire('.');
 
 test('main', async t => {
 	t.deepEqual(


### PR DESCRIPTION
Fixes #4.

**Note on the tests:**
Since a new feature (concurrency), was added, a new test was also added. However, testing the concurrency feature *on this package* is near impossible due to the way promises and `p-limit` are built. I.e. the "limit" (which is the turning point in which we can test how many promisses are running concurrently) is obfuscated by the `p-limit` package itself (line 26 of `p-limit/index.js`). Hence, a test like the one on `p-map` (line 28 of `p-map/test.js`) is not feasible.
My solution was to stub the `p-limit` package (while still letting it run through) and record all the calls made (a spy wont do in this case). That way, we can ensure that the concurrency value and Promise are being sent correctly to `p-limit` and, by extension, making sure the concurrency option is being applied.
Code-wise:
```javascript
const limit = pLimit(opts.concurrency);   <-- tested on 2)

return Promise.all(iterable.map(item => pReflect(limit(() => item))));
         A                   A              A      A           A
         |                   |              |      |           |
          ------ tested on 1) and 3) ------        |           |
                                                    tested on 2)

1) test('main', ...)
2) test('concurrency and item are passed to p-limit', ...)
3) test('handles empty iterable', ...)
```

~~PS: tests are failing due to the same linting issues on the master branch - all actual tests are passing~~