### PR TITLE
change: concurrency not supported for thenable objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,11 @@
 const pReflect = require('p-reflect');
 const pLimit = require('p-limit');
 
-module.exports = (iterable, options) => {
+module.exports = (iterable, mapper, options) => {
+	if (typeof mapper !== 'function') {
+		options = mapper;
+		mapper = false;
+	}
 	options = Object.assign({
 		concurrency: Infinity
 	}, options);
@@ -10,8 +14,19 @@ module.exports = (iterable, options) => {
 	if (!(typeof options.concurrency === 'number' && options.concurrency >= 1)) {
 		throw new TypeError(`Expected \`concurrency\` to be a number from 1 and up, got \`${options.concurrency}\` (${typeof options.concurrency})`);
 	}
+	if (iterable.find(item => typeof item.then === 'function') && options.concurrency) {
+		throw new Error('Cannot limit concurrency for thenable objects')
+	}
 
 	const limit = pLimit(options.concurrency);
 
-	return Promise.all(iterable.map(item => pReflect(limit(() => item))));
+	return Promise.all(iterable.map(item => {
+		if (typeof item.then === 'function') {
+			return pReflect(item);
+		} else if (mapper) {
+			return pReflect(limit(() => mapper(item)));
+		} else {
+			return pReflect(limit(() => item()));
+		}
+	}));
 };


### PR DESCRIPTION
Fixes #6 by supporting three cases:

* An array of already instantiated promises, which *cannot* use concurrency control.
* An array of functions which return promises, which *can* use concurrency control.
* An array of non-thenable values plus a mapper function, which *can* use concurrency control.

