### PR TITLE
Fix TypeScript type return value when the first argument is an array of functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ declare namespace pSettle {
 	type PromiseResult<ValueType> = pReflect.PromiseResult<ValueType>;
 	type PromiseFulfilledResult<ValueType> = pReflect.PromiseFulfilledResult<ValueType>;
 	type PromiseRejectedResult = pReflect.PromiseRejectedResult;
+	type ReturnValue<T> = T extends (...args: any) => any ? ReturnType<T> : T;
 
 	// TODO: Use the native version when TS supports it (should be in v4).
 	type Awaited<T> = T extends undefined ? T : T extends PromiseLike<infer U> ? U : T;
@@ -58,6 +59,6 @@ import pSettle = require('p-settle');
 declare function pSettle<ValueType extends readonly any[]>(
 	array: ValueType,
 	options?: pSettle.Options
-): Promise<{-readonly [P in keyof ValueType]: pSettle.PromiseResult<pSettle.Awaited<ValueType[P]>>}>;
+): Promise<{-readonly [P in keyof ValueType]: pSettle.PromiseResult<pSettle.Awaited<pSettle.ReturnValue<ValueType[P]>>>}>;
 
 export = pSettle;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,6 +6,7 @@ expectType<Promise<Array<PromiseResult<number>>>>(pSettle([1, Promise.resolve(2)
 expectType<Promise<Array<PromiseResult<number>>>>(
 	pSettle([1, Promise.resolve(2)], {concurrency: 1})
 );
+expectType<Promise<Array<PromiseResult<number>>>>(pSettle([async () => 2]));
 
 expectType<Promise<[PromiseResult<number>, PromiseResult<string>]>>(pSettle([1, '2']));
 expectType<Promise<[PromiseResult<string>, PromiseResult<number>]>>(pSettle([Promise.resolve('1'), Promise.resolve(2)]));


### PR DESCRIPTION
A type definition of the return value of `pSettle` is incorrect when the first argument(`array`) is an array of functions.

```ts
pSettle([async () => 2]);
// master: returns Promise<Array<PromiseResult<() => Promise<number>>>>
// this PR: returns Promise<Array<PromiseResult<number>>>
```